### PR TITLE
Feat: Enable HBAR campaigns

### DIFF
--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -6,9 +6,12 @@ import './MultiRewards.sol';
 /// @notice Factory contract for deploying Yield Farming campaigns
 contract Factory is Owned {
 
+    address public WHBAR;
     MultiRewards[] public campaigns;
 
-    constructor() public Owned(msg.sender) {}
+    constructor(address _whbar) public Owned(msg.sender) {
+        WHBAR = _whbar;
+    }
 
     event CampaignDeployed(address campaign, address stakingToken);
 
@@ -16,7 +19,7 @@ contract Factory is Owned {
     /// @param _owner The owner to be set for the campaign
     /// @param _stakingToken The token that will be staked by users
     function deploy(address _owner, address _stakingToken) external onlyOwner {
-        MultiRewards newCampaign = new MultiRewards(_owner, _stakingToken);
+        MultiRewards newCampaign = new MultiRewards(_owner, _stakingToken, WHBAR);
         campaigns.push(newCampaign);
 
         emit CampaignDeployed(address(newCampaign), _stakingToken);

--- a/contracts/interfaces/IWHBAR.sol
+++ b/contracts/interfaces/IWHBAR.sol
@@ -1,0 +1,8 @@
+pragma solidity >=0.5.0;
+
+interface IWHBAR {
+    function deposit() external payable;
+    function transfer(address to, uint value) external returns (bool);
+    function withdraw(uint) external;
+    function approve(address to, uint256 amount) external returns (bool);
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -67,6 +67,16 @@ task('approveToken', 'Approves an HTS token for spending by an account')
         );
     });
 
+task('setupHbarCampaign', 'Deploys HBAR campaign')
+    .addParam('factory', 'Factory contract address')
+    .addParam('token', 'The staking token to user for the campaign')
+    .addParam('hbaramount', 'Amount of HBARs to distribute as rewards')
+    .addParam('duration', 'Duration of the campaign')
+    .setAction(async taskArgs => {
+        const setupHbarCampaign = require('./scripts/setup-hbar-campaign');
+        await setupHbarCampaign(taskArgs.factory, taskArgs.token, taskArgs.hbaramount, taskArgs.duration);
+    })
+
 module.exports = {
     solidity: {
         compilers: [

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "index.js",
   "scripts": {
     "deployFactory": "npx hardhat deployFactory",
-    "deployCampaign": "npx hardhat deployCampaign --factory 0x0000000000000000000000000000000002dcd65c --owner 0x0000000000000000000000000000000002da202b --token 0x978264868aA0730718FBe0A3CCCF8C09f6eb74C3",
+    "deployCampaign": "npx hardhat deployCampaign --factory 0x0000000000000000000000000000000002dd972f --owner 0x0000000000000000000000000000000002da202b --token 0x978264868aA0730718FBe0A3CCCF8C09f6eb74C3",
     "enableReward": "npx hardhat enableReward --campaign 0x0000000000000000000000000000000002dcD66B --reward 0x0000000000000000000000000000000002dce0b7 --duration 2629743",
     "sendReward": "npx hardhat sendReward --campaign 0x0000000000000000000000000000000002dcD66B --reward 0x0000000000000000000000000000000002dce0b7 --amount 200000000000",
     "associateToken": "npx hardhat associateToken --accountid 0.0.47849515 --pk <PK> --tokenid 0.0.48029879",
-    "approveToken": "npx hardhat approveToken --accountid 0.0.47849515 --pk <PK> --spenderaccountid 0.0.48027243 --tokenid 0.0.48029879 --amount 200000000000"
+    "approveToken": "npx hardhat approveToken --accountid 0.0.47849515 --pk <PK> --spenderaccountid 0.0.48027243 --tokenid 0.0.48029879 --amount 200000000000",
+    "setupHbarCampaign": "npx hardhat setupHbarCampaign --factory 0x0000000000000000000000000000000002dd972f --token 0x978264868aA0730718FBe0A3CCCF8C09f6eb74C3 --hbaramount 100 --duration 1000"
   },
   "repository": "https://github.com/LimeChain/HeliSwap-yield-farming",
   "author": "Martin Dobrev",

--- a/scripts/01-deploy-factory.ts
+++ b/scripts/01-deploy-factory.ts
@@ -1,11 +1,15 @@
 // @ts-nocheck
 import hardhat from 'hardhat';
 
+// Canonical WHBAR Address on Testnet
+// Reference https://github.com/LimeChain/whbar
+const WHBAR_ADDRESS = '0x0000000000000000000000000000000002be8c90';
+
 async function deployFactory() {
     const Factory = await hardhat.hethers.getContractFactory('Factory');
 
     console.log('⚙️ Deploying factory contract...');
-    const factory = await Factory.deploy();
+    const factory = await Factory.deploy(WHBAR_ADDRESS);
     await factory.deployed();
 
     console.log('✅ MultiRewards Factory contract deployed to:', factory.address);

--- a/scripts/02-deploy-campaign.ts
+++ b/scripts/02-deploy-campaign.ts
@@ -14,6 +14,7 @@ async function deployCampaignFromFactory(factory: string, owner: string, token: 
 
     const campaign = await Factory.campaigns(numberOfCampaigns - 1, { gasLimit: 50_000 });
     console.log('✅ MultiRewards contract deployed to:', campaign);
+    return campaign;
 }
 
 module.exports = deployCampaignFromFactory;

--- a/scripts/setup-hbar-campaign.ts
+++ b/scripts/setup-hbar-campaign.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+import hardhat from 'hardhat';
+
+const deployCampaignFromFactory = require('./02-deploy-campaign');
+const enableRewards = require('./03-enable-rewards');
+const sendRewards = require('./04-send-reward');
+
+// Canonical WHBAR Address on Testnet
+// Reference https://github.com/LimeChain/whbar
+const WHBAR_ADDRESS = '0x0000000000000000000000000000000002be8c90';
+
+async function setupHbarCampaign(factory: string, token: string, hbarAmount: string, duration: string) {
+    const deployer = (await hardhat.hethers.getSigners())[0];
+
+    // 1. Deploy new Campaign
+    const campaign = await deployCampaignFromFactory(factory, deployer.address, token);
+
+    // 2. Wrap HBARs
+    const WHBAR = await hardhat.hethers.getContractAt('IWHBAR', WHBAR_ADDRESS);
+    // THIS VALUE IS IN HBARS not TINYBARS!!!
+    const depositTx = await WHBAR.deposit({value: hbarAmount, gasLimit: 150_000});
+    await depositTx.wait();
+    console.log(`Wrapped ${hbarAmount} of HBARs into WHBAR`);
+
+    // 3. Approve WHBARs
+    const approveTx = await WHBAR.approve(campaign, hbarAmount);
+    await approveTx.wait();
+    console.log(`Approved Campaign contract ${campaign} for ${hbarAmount} of WHBARs`);
+
+    // 4. Enable WHBAR Rewards
+    await enableRewards(campaign, WHBAR_ADDRESS, duration);
+
+    // 5. Send Rewards
+    await sendRewards(campaign, WHBAR_ADDRESS, hbarAmount);
+}
+
+module.exports = setupHbarCampaign;


### PR DESCRIPTION
Fixes #15 

1. Added canonical WHBAR address to the factory. It is propagated to MultiRewards contracts on deployment
2. Updated the `getReward()` function to `withdraw` and transfer HBAR rewards
3. Updated deployment scripts
4. Added new `setup-hbar-campaign` script that will be utilised for the deployment of hbar campaigns

Signed-off-by: Daniel Ivanov <daniel.k.ivanov95@gmail.com>